### PR TITLE
Set y scrolling on nav

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -5,6 +5,7 @@ body {
 
 #toc {
   position: fixed;
+  overflow-y: scroll;
   left: 0;
   top: 0;
   height: 100%;


### PR DESCRIPTION
The Sidebar did not allow to scroll if the content was longer than the viewport height.
I set the overflow on the y axis to scroll. Now it is scrollable.